### PR TITLE
.munki template for Native Instruments AutoPkg Recipes

### DIFF
--- a/Native Instruments/NativeInstrumentsProduct.munki.recipe
+++ b/Native Instruments/NativeInstrumentsProduct.munki.recipe
@@ -1,0 +1,65 @@
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- This recipes is intended to be overridden. Use `autopkg make-overrde to create an override for each product you want -->
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads and imports the latest versions of the Native Instruments software suite into Munki</string>
+	<key>Identifier</key>
+	<string>com.github.andrewvalentine.munki.native-instruments.product</string>
+	<key>Input</key>
+	<dict>
+		<key>CATEGORY</key>
+		<string></string>
+		<key>DESCRIPTION</key>
+		<string></string>
+		<key>DEVELOPER</key>
+		<string></string>
+		<key>DISPLAY_NAME</key>
+		<string></string>
+		<key>DOWNLOADS</key>
+		<string></string>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string></string>
+		<key>NAME</key>
+		<string>Native Instruments Product</string>
+		<key>PRODUCT_UUID</key>
+		<string></string>
+		<!-- Only the latest version is currently supported. This does nothing. -->
+		<key>VERSION</key>
+		<string>LATEST</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>category</key>
+			<string>%CATEGORY%</string>
+			<key>description</key>
+			<string>%DESCRIPTION%</string>
+			<key>developer</key>
+			<string>%DEVELOPER%</string>
+			<key>display_name</key>
+			<string>%DISPLAY_NAME%</string>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.uoe-macos.download.native-instruments.product</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%download_path%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
As discussed via DM on the Mac Admins Slack, here's a `.munki` template for use with the UoE Native Instruments AutoPkg Recipes repo.

### Notes

* Each override will be created with the following blank pkginfo keys that you the admin may modify to their requirements:
  * `CATEGORY`
  * `DESCRIPTION`
  * `DEVELOPER`
  * `DISPLAY_NAME`
  * `MUNKI_REPO_SUBDIR`

### Instructions 

Usage instructions are easily adapted from the `.pkg` recipe guidance:

1. Create an override:

```
autopkg make-override NativeInstrumentsProduct.munki.recipe
```

2. Make an overrides directory:

```
mkdir ~/Library/AutoPkg/RecipeOverrides/NativeInstruments
```

3. Create the overrides:

```
python ~/Library/AutoPkg/RecipeRepos/com.github.uoe-macos.autopkg-recipes/Native\ Instruments/native_instruments_helper.py\
                --template-autopkg-override \
                --template-override-source ~/Library/AutoPkg/RecipeOverrides/NativeInstrumentsProduct.munki.recipe \
                --template-override-dest-dir ~/Library/AutoPkg/RecipeOverrides/NativeInstruments \
                --suite=komplete --major-version=11
```

4. Run the overrides:

```
autopkg run ~/Library/AutoPkg/RecipeOverrides/NativeInstruments/*
```

Hope it's all good 👍 