### PR TITLE
Update autopkg run instructions

### DIFF
--- a/Avid Pro Tools/ProTools2019.pkg.recipe
+++ b/Avid Pro Tools/ProTools2019.pkg.recipe
@@ -96,7 +96,7 @@ rm -f $PLIST # In case Pro Tools has been updated from a previous version
 
 # Silence Avid Link, courtesy of @neillmartin83
 ​
-loggedInUser=$( scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ && ! /loginwindow/ { print $3 }' )
+loggedInUser=$( scutil &lt;&lt;&lt; "show State:/Users/ConsoleUser" | awk '/Name :/ &amp;&amp; ! /loginwindow/ { print $3 }' )
 ​
 if [[ "$loggedInUser" != "" ]]; then
 	/bin/echo "User $loggedInUser is logged in, quitting Avid Link"

--- a/Native Instruments/README.md
+++ b/Native Instruments/README.md
@@ -36,7 +36,7 @@ or
 
 autopkg make-override NativeInstrumentsProduct.munki.recipe
 ```
-You might wan to edit the file override created by this step, to specify a custom Download location or (if you have used the `.munki` recipe) to set some munki variables approproate to your environment. 
+You might want to edit the file override created by this step, to specify a custom Download location or (if you have used the `.munki` recipe) to set some munki variables appropriate to your environment. 
 
 2. Next, use the helper tool to use this file as a template to generate overrides for each of the products you want to package. This will simply copy the template override file you made in step 1 multiple times, replacing the relevant name and UUID for each product. the example below assumes you are using the `.pkg` recipe: be sure to replace `--template-override-source` with the correct file.
 ```
@@ -56,6 +56,11 @@ If you like, you can instead use the `--product-uuid` argument to template an ov
 autopkg run ~/Library/AutoPkg/RecipeOverrides/NativeInstruments/*
 ```
 and wait a while.
+
+Note that, if you are a Munki user, you only need to run the `.munki` recipes:
+```
+autopkg run ~/Library/AutoPkg/RecipeOverrides/NativeInstruments/*.munki.recipe
+```
 
 ## Processor Configuration
 Some configuration variables are available in the `NIDownloadProvider` processor:


### PR DESCRIPTION
I meant to add this to my previous PR. Sorry!

There's no need for Munki users to run all the generated overrides (i.e. the `.pkg` _and_ `.munki` recipes), so explicit `autopkg run` instructions added that specify how to run only the `.munki` recipes.