### PR TITLE
Fixes for AutoPkg 2.0, Part 2

### DIFF
--- a/Avid Pro Tools/ProTools2018.pkg.recipe
+++ b/Avid Pro Tools/ProTools2018.pkg.recipe
@@ -13,7 +13,7 @@
 		<key>RELEASE</key>
 		<string>1</string>
 		<key>ID</key>
-		<key>com.github.uoe-macos.pkg.ProTools2018.pkg</key>
+		<string>com.github.uoe-macos.pkg.ProTools2018.pkg</string>
 		<key>NAME</key>
 		<string>ProTools2018</string>
 	</dict>

--- a/Avid Pro Tools/ProTools2019.pkg.recipe
+++ b/Avid Pro Tools/ProTools2019.pkg.recipe
@@ -13,7 +13,7 @@
 		<key>RELEASE</key>
 		<string>1</string>
 		<key>ID</key>
-		<key>com.github.uoe-macos.pkg.ProTools2019.pkg</key>
+		<string>com.github.uoe-macos.pkg.ProTools2019.pkg</string>
 		<key>NAME</key>
 		<string>ProTools2019</string>
 	</dict>

--- a/Native Instruments/NativeInstrumentsProduct.munki.recipe
+++ b/Native Instruments/NativeInstrumentsProduct.munki.recipe
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- This recipes is intended to be overridden. Use `autopkg make-overrde to create an override for each product you want -->
 <plist version="1.0">
 <dict>
 	<key>Description</key>
 	<string>Downloads and imports the latest versions of the Native Instruments software suite into Munki</string>
 	<key>Identifier</key>
-	<string>com.github.andrewvalentine.munki.native-instruments.product</string>
+	<string>com.github.uoe-macos.munki.native-instruments.product</string>
 	<key>Input</key>
 	<dict>
 		<key>CATEGORY</key>
@@ -24,6 +24,7 @@
 		<string>Native Instruments Product</string>
 		<key>PRODUCT_UUID</key>
 		<string></string>
+		<!-- Only the latest version is currently supported. This does nothing. -->
 		<key>VERSION</key>
 		<string>LATEST</string>
 		<key>pkginfo</key>

--- a/Native Instruments/NativeInstrumentsProduct.munki.recipe
+++ b/Native Instruments/NativeInstrumentsProduct.munki.recipe
@@ -1,5 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!-- This recipes is intended to be overridden. Use `autopkg make-overrde to create an override for each product you want -->
 <plist version="1.0">
 <dict>
 	<key>Description</key>
@@ -24,7 +24,6 @@
 		<string>Native Instruments Product</string>
 		<key>PRODUCT_UUID</key>
 		<string></string>
-		<!-- Only the latest version is currently supported. This does nothing. -->
 		<key>VERSION</key>
 		<string>LATEST</string>
 		<key>pkginfo</key>
@@ -50,8 +49,6 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
@@ -59,6 +56,8 @@
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
New PR raised following erroneous removal of comments from previous commit.

**Avid recipes**
- Convert `identifier` value from `key` to `string`

**NativeInstrumentsProduct.munki.recipe**
- Restore helpful comments.
- Update identifier to match others in parent recipe. Changing identifiers of existing recipes is not best practice, but this should be done in order maintain consistency with the other recipes.
- Convert to proper XML formatting.